### PR TITLE
Fix leagueSeasonEvents parameter for league_id

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,41 @@
+"""Test cases for events module."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from thesportsdb.events import leagueSeasonEvents
+
+
+@pytest.fixture
+def mock_request(monkeypatch):
+    """Create a mock for the make_request function."""
+    mock = Mock()
+    monkeypatch.setattr("thesportsdb.events.make_request", mock)
+    return mock
+
+
+def test_league_season_events(mock_request):
+    """Test getting events for a league and season."""
+    mock_request.return_value = {"events": [{"strEvent": "Arsenal vs Chelsea"}]}
+    result = leagueSeasonEvents("4328", "2021-2022")
+    mock_request.assert_called_with("/eventsseason.php", id="4328", s="2021-2022")
+    assert result["events"][0]["strEvent"] == "Arsenal vs Chelsea"
+
+
+def test_league_season_events_with_different_parameters(mock_request):
+    """Test leagueSeasonEvents with different league and season parameters."""
+    mock_request.return_value = {
+        "events": [{"strEvent": "Liverpool vs Manchester City"}]
+    }
+    result = leagueSeasonEvents("4329", "2020-2021")
+    mock_request.assert_called_with("/eventsseason.php", id="4329", s="2020-2021")
+    assert result["events"][0]["strEvent"] == "Liverpool vs Manchester City"
+
+
+def test_league_season_events_empty_response(mock_request):
+    """Test leagueSeasonEvents when API returns empty result."""
+    mock_request.return_value = {"events": None}
+    result = leagueSeasonEvents("4328", "2021-2022")
+    mock_request.assert_called_with("/eventsseason.php", id="4328", s="2021-2022")
+    assert result["events"] is None

--- a/thesportsdb/events.py
+++ b/thesportsdb/events.py
@@ -13,6 +13,7 @@ All Event API interactions on the free tier.
 """
 
 from __future__ import absolute_import
+
 import thesportsdb.settings as TSD
 from thesportsdb.requests import make_request
 
@@ -36,7 +37,7 @@ def leagueSeasonEvents(league_id: str, season: str):
     Get the  Events for this league identified by the `league_id` for the
     `season` specified.
     """
-    return make_request(TSD.LEAGUE_SEASON_EVENTS, l=league_id, s=season)
+    return make_request(TSD.LEAGUE_SEASON_EVENTS, id=league_id, s=season)
 
 
 def leagueSeasonRoundEvents(league_id: str, season: str, round: str):


### PR DESCRIPTION
The `eventsseason.php` endpoint has changed its parameter for league ID from `l` to `id`:

Example: https://www.thesportsdb.com/api/v1/json/123/eventsseason.php?id=4328&s=2014-2015

I've updated the `leagueSeasonEvents` method accordingly and added unit tests following the existing patterns in `test_search.py`.

To reproduce:
```python
from pprint import pprint

import thesportsdb


def main():
    events = thesportsdb.events.leagueSeasonEvents("4430", "2025-2026")
    pprint(events)


if __name__ == "__main__":
    main()
```
This code produce an error from the API: `{'events': 'Invalid League ID passed'}`